### PR TITLE
adding config for custom ctags

### DIFF
--- a/autoload/vimentry.vim
+++ b/autoload/vimentry.vim
@@ -94,6 +94,8 @@ function vimentry#write_default_template()
                 \ s:write_default( "enable_tags", "true", "{ true, false }" ),
                 \ s:write_default( "enable_symbols", "true", "{ true, false }" ),
                 \ s:write_default( "enable_inherits", "true", "{ true, false }" ),
+                \ s:write_default( "enable_custom_tags", "false", "{ true, false }" ),
+                \ s:write_default( "custom_tags_file" , "", "" ),
                 \ "",
                 \ "-- ex-cscope Options:",
                 \ s:write_default( "enable_cscope", "false", "{ true, false }" ),


### PR DESCRIPTION
I added a support for custom ctags. I work on LibreOffice and some of the ctags created with exuberant-ctags are too long for the tags plugin in exVim. LibreOffice does have a custom "make tags" command which creates a correct tags file. This config options allows users to use custom created tags files if they want to (pull request in the other projects added as well).